### PR TITLE
Add keybind instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,18 @@ The default key assignment to open the Leap widget is `Ctrl + Alt + F` and with 
 
 ## Extension Settings
 
-The ability to select a custom keymap is planned for future releases.
+Define new keybinds using the `"leap.find"` and `"leap.match-case"` commands. 
+
+Example using the [Vim extension](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim), mimicking [leap.nvim](https://github.com/ggandor/leap.nvim):
+
+```json
+"vim.normalModeKeyBindingsNonRecursive": [
+    {
+        "before": ["s"],
+        "commands": ["leap.find"]
+    }
+]
+```
 
 ## Known Issues
 


### PR DESCRIPTION
The README says custom remaps are impossible, but that's not true. The extension exposes the `leap.find` and `leap.match-case` commands, allowing remapping in the Keyboard Shortcuts interface. 

This is also possible with the Vim extension. I added instructions for that since I expect many users of this extension to be users of the original neovim one looking for similar behaviour as I am.